### PR TITLE
Reactor 3.1 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
-            <version>3.1.0.M1</version>
+            <version>3.1.0.M3</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,94 +1,107 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.sonatype.oss</groupId>
-    <artifactId>oss-parent</artifactId>
-    <version>7</version>
-  </parent>
+    <parent>
+        <groupId>org.sonatype.oss</groupId>
+        <artifactId>oss-parent</artifactId>
+        <version>7</version>
+    </parent>
 
-  <groupId>com.jakewharton.retrofit</groupId>
-  <artifactId>retrofit2-reactor-adapter</artifactId>
-  <version>1.0.1-SNAPSHOT</version>
+    <groupId>com.jakewharton.retrofit</groupId>
+    <artifactId>retrofit2-reactor-adapter</artifactId>
+    <version>1.0.1-SNAPSHOT</version>
 
-  <name>Retrofit 2 Project Reactor Adapter</name>
-  <description>A Project Reactor 3.x CallAdapter.Factory implementation for Retrofit 2.</description>
-  <inceptionYear>2016</inceptionYear>
+    <name>Retrofit 2 Project Reactor Adapter</name>
+    <description>A Project Reactor 3.x CallAdapter.Factory implementation for Retrofit 2.</description>
+    <inceptionYear>2016</inceptionYear>
 
-  <scm>
-    <url>http://github.com/JakeWharton/retrofit2-reactor-adapter</url>
-    <connection>scm:git:git://github.com/JakeWharton/retrofit2-reactor-adapter.git</connection>
-    <developerConnection>scm:git:git@github.com:JakeWharton/retrofit2-reactor-adapter.git</developerConnection>
-  </scm>
+    <scm>
+        <url>http://github.com/JakeWharton/retrofit2-reactor-adapter</url>
+        <connection>scm:git:git://github.com/JakeWharton/retrofit2-reactor-adapter.git</connection>
+        <developerConnection>scm:git:git@github.com:JakeWharton/retrofit2-reactor-adapter.git</developerConnection>
+    </scm>
 
-  <issueManagement>
-    <system>GitHub Issues</system>
-    <url>http://github.com/JakeWharton/retrofit2-reactor-adapter/issues</url>
-  </issueManagement>
+    <repositories>
+        <!-- Repositories to allow milestone BOM imports during development. -->
+        <repository>
+            <id>spring-milestones</id>
+            <name>Spring Milestones</name>
+            <url>http://repo.spring.io/milestone</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 
-  <licenses>
-    <license>
-      <name>Apache License Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-      <distribution>repo</distribution>
-    </license>
-  </licenses>
+    <issueManagement>
+        <system>GitHub Issues</system>
+        <url>http://github.com/JakeWharton/retrofit2-reactor-adapter/issues</url>
+    </issueManagement>
 
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.version>1.8</java.version>
-  </properties>
+    <licenses>
+        <license>
+            <name>Apache License Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
 
-  <dependencies>
-    <dependency>
-      <groupId>com.squareup.retrofit2</groupId>
-      <artifactId>retrofit</artifactId>
-      <version>2.1.0</version>
-    </dependency>
-    <dependency>
-      <groupId>io.projectreactor</groupId>
-      <artifactId>reactor-core</artifactId>
-      <version>3.0.2.RELEASE</version>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>mockwebserver</artifactId>
-      <version>3.4.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <version>3.1.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>19.0</version>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.version>1.8</java.version>
+    </properties>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.3</version>
-        <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
+    <dependencies>
+        <dependency>
+            <groupId>com.squareup.retrofit2</groupId>
+            <artifactId>retrofit</artifactId>
+            <version>2.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+            <version>3.1.0.M1</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>3.4.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.1.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>19.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/main/java/com/jakewharton/retrofit2/adapter/reactor/BodyFlux.java
+++ b/src/main/java/com/jakewharton/retrofit2/adapter/reactor/BodyFlux.java
@@ -18,6 +18,7 @@ package com.jakewharton.retrofit2.adapter.reactor;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Operators;
 import retrofit2.Response;
@@ -29,8 +30,9 @@ final class BodyFlux<T> extends Flux<T> {
     this.upstream = upstream;
   }
 
-  @Override public void subscribe(Subscriber<? super T> subscriber) {
-    upstream.subscribe(new BodySubscriber<>(subscriber));
+  @Override
+  public void subscribe(CoreSubscriber<? super T> coreSubscriber) {
+    upstream.subscribe(new BodySubscriber<>(coreSubscriber));
   }
 
   private static class BodySubscriber<R> implements Subscriber<Response<R>> {

--- a/src/main/java/com/jakewharton/retrofit2/adapter/reactor/CallSinkConsumer.java
+++ b/src/main/java/com/jakewharton/retrofit2/adapter/reactor/CallSinkConsumer.java
@@ -15,11 +15,12 @@
  */
 package com.jakewharton.retrofit2.adapter.reactor;
 
-import java.io.IOException;
-import java.util.function.Consumer;
 import reactor.core.publisher.FluxSink;
 import retrofit2.Call;
 import retrofit2.Response;
+
+import java.io.IOException;
+import java.util.function.Consumer;
 
 final class CallSinkConsumer<T> implements Consumer<FluxSink<Response<T>>> {
   private final Call<T> originalCall;
@@ -32,7 +33,7 @@ final class CallSinkConsumer<T> implements Consumer<FluxSink<Response<T>>> {
     // Since Call is a one-shot type, clone it for each new subscriber.
     Call<T> call = originalCall.clone();
 
-    sink.setCancellation(call::cancel);
+    sink.onDispose(call::cancel);
 
     Response<T> response;
     try {

--- a/src/main/java/com/jakewharton/retrofit2/adapter/reactor/ResultFlux.java
+++ b/src/main/java/com/jakewharton/retrofit2/adapter/reactor/ResultFlux.java
@@ -18,52 +18,58 @@ package com.jakewharton.retrofit2.adapter.reactor;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Operators;
 import retrofit2.Response;
 
 final class ResultFlux<T> extends Flux<Result<T>> {
-  private final Publisher<Response<T>> upstream;
+    private final Publisher<Response<T>> upstream;
 
-  ResultFlux(Publisher<Response<T>> upstream) {
-    this.upstream = upstream;
-  }
-
-  @Override public void subscribe(Subscriber<? super Result<T>> subscriber) {
-    upstream.subscribe(new ResultSubscriber<>(subscriber));
-  }
-
-  private static class ResultSubscriber<R> implements Subscriber<Response<R>> {
-    private final Subscriber<? super Result<R>> subscriber;
-
-    ResultSubscriber(Subscriber<? super Result<R>> subscriber) {
-      this.subscriber = subscriber;
+    ResultFlux(Publisher<Response<T>> upstream) {
+        this.upstream = upstream;
     }
 
-    @Override public void onSubscribe(Subscription s) {
-      subscriber.onSubscribe(s);
+    @Override
+    public void subscribe(CoreSubscriber<? super Result<T>> coreSubscriber) {
+        upstream.subscribe(new ResultSubscriber<>(coreSubscriber));
     }
 
-    @Override public void onNext(Response<R> response) {
-      subscriber.onNext(Result.response(response));
-    }
+    private static class ResultSubscriber<R> implements Subscriber<Response<R>> {
+        private final Subscriber<? super Result<R>> subscriber;
 
-    @Override public void onError(Throwable throwable) {
-      try {
-        subscriber.onNext(Result.<R>error(throwable));
-      } catch (Throwable t) {
-        try {
-          subscriber.onError(t);
-        } catch (Throwable inner) {
-          Operators.onErrorDropped(inner, t);
+        ResultSubscriber(Subscriber<? super Result<R>> subscriber) {
+            this.subscriber = subscriber;
         }
-        return;
-      }
-      subscriber.onComplete();
-    }
 
-    @Override public void onComplete() {
-      subscriber.onComplete();
+        @Override
+        public void onSubscribe(Subscription s) {
+            subscriber.onSubscribe(s);
+        }
+
+        @Override
+        public void onNext(Response<R> response) {
+            subscriber.onNext(Result.response(response));
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            try {
+                subscriber.onNext(Result.<R>error(throwable));
+            } catch (Throwable t) {
+                try {
+                    subscriber.onError(t);
+                } catch (Throwable inner) {
+                    Operators.onErrorDropped(inner, t);
+                }
+                return;
+            }
+            subscriber.onComplete();
+        }
+
+        @Override
+        public void onComplete() {
+            subscriber.onComplete();
+        }
     }
-  }
 }

--- a/src/test/java/com/jakewharton/retrofit2/adapter/reactor/TestScheduler.java
+++ b/src/test/java/com/jakewharton/retrofit2/adapter/reactor/TestScheduler.java
@@ -1,11 +1,12 @@
 package com.jakewharton.retrofit2.adapter.reactor;
 
+import reactor.core.Disposable;
+import reactor.core.scheduler.Scheduler;
+
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
-import reactor.core.Cancellation;
-import reactor.core.scheduler.Scheduler;
 
 final class TestScheduler implements Scheduler {
   private final Deque<Runnable> tasks = new ArrayDeque<>();
@@ -16,21 +17,23 @@ final class TestScheduler implements Scheduler {
     }
   }
 
-  @Override public Cancellation schedule(Runnable task) {
+  @Override public Disposable schedule(Runnable task) {
     return createWorker().schedule(task);
   }
 
   @Override public Worker createWorker() {
     return new Worker() {
+
       private final List<Runnable> workerTasks = new ArrayList<>();
 
-      @Override public Cancellation schedule(Runnable task) {
+      @Override public Disposable schedule(Runnable task) {
         workerTasks.add(task);
         tasks.add(task);
         return () -> tasks.remove(task);
       }
 
-      @Override public void shutdown() {
+      @Override
+      public void dispose() {
         tasks.removeAll(workerTasks);
       }
     };


### PR DESCRIPTION
`Cancellation` interface was replaced with `Disposable` in Reactor 3.1

Not sure if it is proper fix. 