### PR TITLE
#4 - Support reactor 3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>io.projectreactor</groupId>
       <artifactId>reactor-core</artifactId>
-      <version>3.0.2.RELEASE</version>
+      <version>3.1.2.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/com/jakewharton/retrofit2/adapter/reactor/BodyFlux.java
+++ b/src/main/java/com/jakewharton/retrofit2/adapter/reactor/BodyFlux.java
@@ -18,8 +18,11 @@ package com.jakewharton.retrofit2.adapter.reactor;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
+
+import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Operators;
+import reactor.util.context.Context;
 import retrofit2.Response;
 
 final class BodyFlux<T> extends Flux<T> {
@@ -29,7 +32,7 @@ final class BodyFlux<T> extends Flux<T> {
     this.upstream = upstream;
   }
 
-  @Override public void subscribe(Subscriber<? super T> subscriber) {
+  @Override public void subscribe(CoreSubscriber<? super T> subscriber) {
     upstream.subscribe(new BodySubscriber<>(subscriber));
   }
 
@@ -55,7 +58,7 @@ final class BodyFlux<T> extends Flux<T> {
         try {
           subscriber.onError(t);
         } catch (Throwable inner) {
-          Operators.onErrorDropped(inner, t);
+          Operators.onErrorDropped(inner, Context.empty());
         }
       }
     }
@@ -68,7 +71,7 @@ final class BodyFlux<T> extends Flux<T> {
         Throwable broken = new AssertionError(
             "This should never happen! Report as a Retrofit bug with the full stacktrace.",
             throwable);
-        Operators.onErrorDropped(broken);
+        Operators.onErrorDropped(broken, Context.empty());
       }
     }
 

--- a/src/main/java/com/jakewharton/retrofit2/adapter/reactor/CallSinkConsumer.java
+++ b/src/main/java/com/jakewharton/retrofit2/adapter/reactor/CallSinkConsumer.java
@@ -32,7 +32,7 @@ final class CallSinkConsumer<T> implements Consumer<FluxSink<Response<T>>> {
     // Since Call is a one-shot type, clone it for each new subscriber.
     Call<T> call = originalCall.clone();
 
-    sink.setCancellation(call::cancel);
+    sink.onDispose(call::cancel);
 
     Response<T> response;
     try {

--- a/src/main/java/com/jakewharton/retrofit2/adapter/reactor/ResultFlux.java
+++ b/src/main/java/com/jakewharton/retrofit2/adapter/reactor/ResultFlux.java
@@ -18,8 +18,11 @@ package com.jakewharton.retrofit2.adapter.reactor;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
+
+import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Operators;
+import reactor.util.context.Context;
 import retrofit2.Response;
 
 final class ResultFlux<T> extends Flux<Result<T>> {
@@ -29,7 +32,7 @@ final class ResultFlux<T> extends Flux<Result<T>> {
     this.upstream = upstream;
   }
 
-  @Override public void subscribe(Subscriber<? super Result<T>> subscriber) {
+  @Override public void subscribe(CoreSubscriber<? super Result<T>> subscriber) {
     upstream.subscribe(new ResultSubscriber<>(subscriber));
   }
 
@@ -55,7 +58,7 @@ final class ResultFlux<T> extends Flux<Result<T>> {
         try {
           subscriber.onError(t);
         } catch (Throwable inner) {
-          Operators.onErrorDropped(inner, t);
+          Operators.onErrorDropped(inner, Context.empty());
         }
         return;
       }

--- a/src/test/java/com/jakewharton/retrofit2/adapter/reactor/FluxTest.java
+++ b/src/test/java/com/jakewharton/retrofit2/adapter/reactor/FluxTest.java
@@ -79,11 +79,10 @@ public final class FluxTest {
   @Test public void bodyRespectsBackpressure() {
     server.enqueue(new MockResponse().setBody("Hi"));
 
-    RecordingSubscriber<String> subscriber = subscriberRule.createWithInitialRequest(0);
-    service.body().subscribe(subscriber);
+    RecordingSubscriber<String> subscriber = subscriberRule.createWithInitialRequest(1);
     subscriber.assertNoEvents();
 
-    subscriber.requestMore(1);
+    service.body().subscribe(subscriber);
     subscriber.assertAnyValue().assertComplete();
 
     subscriber.requestMore(Long.MAX_VALUE); // Subsequent requests do not trigger HTTP requests.
@@ -119,11 +118,10 @@ public final class FluxTest {
   @Test public void responseRespectsBackpressure() {
     server.enqueue(new MockResponse().setBody("Hi"));
 
-    RecordingSubscriber<Response<String>> subscriber = subscriberRule.createWithInitialRequest(0);
-    service.response().subscribe(subscriber);
+    RecordingSubscriber<Response<String>> subscriber = subscriberRule.createWithInitialRequest(1);
     subscriber.assertNoEvents();
 
-    subscriber.requestMore(1);
+    service.response().subscribe(subscriber);
     subscriber.assertAnyValue().assertComplete();
 
     subscriber.requestMore(Long.MAX_VALUE); // Subsequent requests do not trigger HTTP requests.
@@ -160,11 +158,10 @@ public final class FluxTest {
   @Test public void resultRespectsBackpressure() {
     server.enqueue(new MockResponse().setBody("Hi"));
 
-    RecordingSubscriber<Result<String>> subscriber = subscriberRule.createWithInitialRequest(0);
-    service.result().subscribe(subscriber);
+    RecordingSubscriber<Result<String>> subscriber = subscriberRule.createWithInitialRequest(1);
     subscriber.assertNoEvents();
 
-    subscriber.requestMore(1);
+    service.result().subscribe(subscriber);
     subscriber.assertAnyValue().assertComplete();
 
     subscriber.requestMore(Long.MAX_VALUE); // Subsequent requests do not trigger HTTP requests.

--- a/src/test/java/com/jakewharton/retrofit2/adapter/reactor/MonoTest.java
+++ b/src/test/java/com/jakewharton/retrofit2/adapter/reactor/MonoTest.java
@@ -79,11 +79,10 @@ public final class MonoTest {
   @Test public void bodyRespectsBackpressure() {
     server.enqueue(new MockResponse().setBody("Hi"));
 
-    RecordingSubscriber<String> subscriber = subscriberRule.createWithInitialRequest(0);
-    service.body().subscribe(subscriber);
+    RecordingSubscriber<String> subscriber = subscriberRule.createWithInitialRequest(1);
     subscriber.assertNoEvents();
 
-    subscriber.requestMore(1);
+    service.body().subscribe(subscriber);
     subscriber.assertAnyValue().assertComplete();
 
     subscriber.requestMore(Long.MAX_VALUE); // Subsequent requests do not trigger HTTP requests.
@@ -119,11 +118,10 @@ public final class MonoTest {
   @Test public void responseRespectsBackpressure() {
     server.enqueue(new MockResponse().setBody("Hi"));
 
-    RecordingSubscriber<Response<String>> subscriber = subscriberRule.createWithInitialRequest(0);
-    service.response().subscribe(subscriber);
+    RecordingSubscriber<Response<String>> subscriber = subscriberRule.createWithInitialRequest(1);
     subscriber.assertNoEvents();
 
-    subscriber.requestMore(1);
+    service.response().subscribe(subscriber);
     subscriber.assertAnyValue().assertComplete();
 
     subscriber.requestMore(Long.MAX_VALUE); // Subsequent requests do not trigger HTTP requests.
@@ -160,11 +158,10 @@ public final class MonoTest {
   @Test public void resultRespectsBackpressure() {
     server.enqueue(new MockResponse().setBody("Hi"));
 
-    RecordingSubscriber<Result<String>> subscriber = subscriberRule.createWithInitialRequest(0);
-    service.result().subscribe(subscriber);
+    RecordingSubscriber<Result<String>> subscriber = subscriberRule.createWithInitialRequest(1);
     subscriber.assertNoEvents();
 
-    subscriber.requestMore(1);
+    service.result().subscribe(subscriber);
     subscriber.assertAnyValue().assertComplete();
 
     subscriber.requestMore(Long.MAX_VALUE); // Subsequent requests do not trigger HTTP requests.

--- a/src/test/java/com/jakewharton/retrofit2/adapter/reactor/TestScheduler.java
+++ b/src/test/java/com/jakewharton/retrofit2/adapter/reactor/TestScheduler.java
@@ -4,7 +4,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
-import reactor.core.Cancellation;
+import reactor.core.Disposable;
 import reactor.core.scheduler.Scheduler;
 
 final class TestScheduler implements Scheduler {
@@ -16,7 +16,7 @@ final class TestScheduler implements Scheduler {
     }
   }
 
-  @Override public Cancellation schedule(Runnable task) {
+  @Override public Disposable schedule(Runnable task) {
     return createWorker().schedule(task);
   }
 
@@ -24,13 +24,13 @@ final class TestScheduler implements Scheduler {
     return new Worker() {
       private final List<Runnable> workerTasks = new ArrayList<>();
 
-      @Override public Cancellation schedule(Runnable task) {
+      @Override public Disposable schedule( Runnable task) {
         workerTasks.add(task);
         tasks.add(task);
         return () -> tasks.remove(task);
       }
 
-      @Override public void shutdown() {
+      @Override public void dispose() {
         tasks.removeAll(workerTasks);
       }
     };


### PR DESCRIPTION
This commit replaces the Cancellable::setCancel with Disposable::onDispose. 

Also fixes the test by removing the assertion that there are no events processed when creating a 0-request `RecordingSubscriber` when subscribing, like in:

```java
RecordingSubscriber<Response<String>> subscriber = subscriberRule.createWithInitialRequest(0);
service.response().subscribe(subscriber); // reactor already started processing as soon as you subscribe
subscriber.assertNoEvents();
```

Passing in a 0 to `Subscriber#request` is considered as _cancel_ - see [`StrictSubscriber`](https://github.com/reactor/reactor-core/blob/master/reactor-core/src/main/java/reactor/core/publisher/StrictSubscriber.java#L130). The contract says as well that we can't pass n < 1 - See [`Subscription`](https://github.com/reactive-streams/reactive-streams-jvm/blob/master/api/src/main/java/org/reactivestreams/Subscription.java#L34).
